### PR TITLE
Improved flexibility of 'replacement' deprecations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 - Default deprecation warning messages no longer include text to indicate that developers should "review the release notes and/or documentation". In cases where further information is required, it should be provided as ``additional_guidance``, which may also include a hyperlink to the relevant release notes / documentation where considered useful.
 - ``DeprecatedAppSetting`` now supports an ``additional_guidance`` argument at initialisation, that can be used to add further context-specific information for each deprecation as required, which will be appended to the default warning text.
 - Added the ``is_value_from_deprecated_setting()`` method to ``BaseAppSettingsHelper`` to help developers determine where a setting value came from when dealing settings that replace deprecated settings.
+- Added support for deprecation scenarios where a new setting might replace multiple other settings.
+- Renamed the ``get_raw()`` method on ``BaseAppSettingsHelper`` to ``get()`` .
 
 
 0.1.0 (27.06.2018)

--- a/cogwheels/exceptions/deprecations.py
+++ b/cogwheels/exceptions/deprecations.py
@@ -25,10 +25,3 @@ class DuplicateDeprecationError(InvalidDeprecationDefinition):
     AppSettingDeprecation definitions in a setting helper's 'deprecations' "
     "list."""
     pass
-
-
-class DuplicateDeprecationReplacementError(InvalidDeprecationDefinition):
-    """The same replacement setting name has been used for more than one
-    AppSettingDeprecation definition in a setting helper's 'deprecations' "
-    "list."""
-    pass

--- a/cogwheels/helpers/settings.py
+++ b/cogwheels/helpers/settings.py
@@ -294,7 +294,7 @@ class BaseAppSettingsHelper:
             deprecations = self._replacement_settings[setting_name]
             for item in deprecations:
                 if(
-                    (len(deprecations) == 1 or item.setting_name == accept_deprecated) or
+                    (len(deprecations) == 1 or item.setting_name == accept_deprecated) and
                     self.is_overridden(item.setting_name)
                 ):
                     item.warn_if_user_using_old_setting_name()

--- a/cogwheels/helpers/settings.py
+++ b/cogwheels/helpers/settings.py
@@ -264,7 +264,7 @@ class BaseAppSettingsHelper:
     def _get_raw_setting_value(self, setting_name):
         """
         Returns the value of the app setting named by ``setting_name``,
-        exactly as it has been defined in the defaults modul or a user's
+        exactly as it has been defined in the defaults module or a user's
         Django settings.
 
         If the requested setting is deprecated, a suitable deprecation
@@ -312,8 +312,9 @@ class BaseAppSettingsHelper:
             not self.is_overridden(setting_name) and
             setting_name in self._replacement_settings
         ):
-            depr = self._replacement_settings[setting_name]
-            return self.is_overridden(depr.setting_name)
+            deprecations = self._replacement_settings[setting_name]
+            return len(deprecations) == 1 and self.is_overridden(
+                deprecations[0].setting_name)
         return False
 
     def get(self, setting_name, enforce_type=None, silence_warnings=False):

--- a/cogwheels/helpers/tests/test_deprecated_settings.py
+++ b/cogwheels/helpers/tests/test_deprecated_settings.py
@@ -136,3 +136,78 @@ class TestReplacedSetting(AppSettingTestCase):
             True,
             self.appsettingshelper.is_value_from_deprecated_setting('REPLACED_SETTING_NEW')
         )
+
+
+@override_settings(
+    COGWHEELS_TESTS_REPLACED_SETTING_ONE='overridden-one',
+    COGWHEELS_TESTS_REPLACED_SETTING_TWO='overridden-two',
+)
+class TestMultipleReplacementSetting(AppSettingTestCase):
+
+    def test_referencing_each_old_setting_on_settings_module_raises_warning(self):
+        for deprecated_setting_name in (
+            'REPLACED_SETTING_ONE', 'REPLACED_SETTING_TWO', 'REPLACED_SETTING_THREE'
+        ):
+            with self.assertWarns(DeprecationWarning):
+                getattr(self.appsettingshelper, deprecated_setting_name)
+
+    def test_user_defined_setting_with_old_name_is_only_used_if_its_name_matches_accept_deprecated(self):
+        # REPLACES_MULTIPLE should return the value from defaults, because a user could be overriding
+        # any one of the deprecated settings being replaced, and because we have no idea which to
+        # prioritize over the other, picking one could yield unpredictable results.
+        self.assertIs(
+            self.appsettingshelper.get('REPLACES_MULTIPLE'), defaults.REPLACES_MULTIPLE
+        )
+        # Instead, developers can specify which deprecated setting in particular they are willing to
+        # use a value from, and override values for those settings will be returned.
+        self.assertEqual(
+            self.appsettingshelper.get('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_ONE'),
+            'overridden-one'
+        )
+        self.assertEqual(
+            self.appsettingshelper.get('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_TWO'),
+            'overridden-two'
+        )
+        # But the the default value will still be returned if the specified deprecated setting has
+        # not been overridden
+        self.assertIs(
+            self.appsettingshelper.get('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_THREE'),
+            defaults.REPLACES_MULTIPLE
+        )
+
+    def test_is_value_from_deprecated_setting_returns_false_if_accept_deprecated_not_used(self):
+        self.assertIs(
+            self.appsettingshelper.is_value_from_deprecated_setting('REPLACES_MULTIPLE'),
+            False
+        )
+
+    @override_settings(COGWHEELS_TESTS_REPLACED_SETTING_OLD='somevalue')
+    def test_is_value_from_deprecated_setting_returns_true_if_the_setting_named_by_accept_deprecated_is_overridden(self):
+        self.assertIs(
+            self.appsettingshelper.is_value_from_deprecated_setting('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_ONE'),
+            True
+        )
+        self.assertIs(
+            self.appsettingshelper.is_value_from_deprecated_setting('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_TWO'),
+            True
+        )
+        self.assertIs(
+            self.appsettingshelper.is_value_from_deprecated_setting('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_THREE'),
+            False
+        )
+
+    @override_settings(COGWHEELS_TESTS_REPLACES_MULTIPLE='somevalue')
+    def test_is_value_from_deprecated_setting_returns_false_if_the_new_setting_is_overridden(self):
+        self.assertIs(
+            self.appsettingshelper.is_value_from_deprecated_setting('REPLACES_MULTIPLE'),
+            False
+        )
+        # And even if 'accept_deprecated' is used, the provided value for the new setting if preferred
+        self.assertIs(
+            self.appsettingshelper.is_value_from_deprecated_setting('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_ONE'),
+            False
+        )
+        self.assertIs(
+            self.appsettingshelper.is_value_from_deprecated_setting('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_TWO'),
+            False
+        )

--- a/cogwheels/helpers/tests/test_deprecated_settings.py
+++ b/cogwheels/helpers/tests/test_deprecated_settings.py
@@ -160,14 +160,17 @@ class TestMultipleReplacementSetting(AppSettingTestCase):
         )
         # Instead, developers can specify which deprecated setting in particular they are willing to
         # use a value from, and override values for those settings will be returned.
-        self.assertEqual(
-            self.appsettingshelper.get('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_ONE'),
-            'overridden-one'
-        )
-        self.assertEqual(
-            self.appsettingshelper.get('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_TWO'),
-            'overridden-two'
-        )
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                self.appsettingshelper.get('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_ONE'),
+                'overridden-one'
+            )
+
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(
+                self.appsettingshelper.get('REPLACES_MULTIPLE', accept_deprecated='REPLACED_SETTING_TWO'),
+                'overridden-two'
+            )
         # But the the default value will still be returned if the specified deprecated setting has
         # not been overridden
         self.assertIs(

--- a/cogwheels/helpers/tests/test_invalid_deprecations.py
+++ b/cogwheels/helpers/tests/test_invalid_deprecations.py
@@ -36,10 +36,3 @@ class TestHelperInitErrors(TestCase):
                 DeprecatedAppSetting('DEPRECATED_SETTING'),
                 DeprecatedAppSetting('DEPRECATED_SETTING'),
             ))
-
-    def test_raises_correct_error_type_if_same_replacement_setting_name_repeated_in_deprecation_definitions(self):
-        with self.assertRaises(exceptions.DuplicateDeprecationReplacementError):
-            TestSettingsHelper(deprecations=(
-                DeprecatedAppSetting('RENAMED_SETTING_OLD', renamed_to='RENAMED_SETTING_NEW'),
-                DeprecatedAppSetting('REPLACED_SETTING_OLD', replaced_by='RENAMED_SETTING_NEW'),
-            ))

--- a/cogwheels/tests/conf/defaults.py
+++ b/cogwheels/tests/conf/defaults.py
@@ -52,3 +52,11 @@ RENAMED_SETTING_NEW = 'renamed_new'
 REPLACED_SETTING_OLD = 'replaced_old'
 
 REPLACED_SETTING_NEW = 'replaced_new'
+
+REPLACED_SETTING_ONE = 'replaced_one'
+
+REPLACED_SETTING_TWO = 'replaced_two'
+
+REPLACED_SETTING_THREE = 'replaced_three'
+
+REPLACES_MULTIPLE = 'replaces_multiple'

--- a/cogwheels/tests/conf/settings.py
+++ b/cogwheels/tests/conf/settings.py
@@ -22,6 +22,18 @@ class TestAppSettingsHelper(BaseAppSettingsHelper):
                 "https://your-django-project.readthedocs.io/en/latest/releases/X.X.html"
             )
         ),
+        DeprecatedAppSetting(
+            'REPLACED_SETTING_ONE',
+            replaced_by='REPLACES_MULTIPLE',
+        ),
+        DeprecatedAppSetting(
+            'REPLACED_SETTING_TWO',
+            replaced_by='REPLACES_MULTIPLE',
+        ),
+        DeprecatedAppSetting(
+            'REPLACED_SETTING_THREE',
+            replaced_by='REPLACES_MULTIPLE',
+        ),
     )
 
 


### PR DESCRIPTION
- Removes the requirement for 'renamed_to' or 'replaced_by' init values to be unique for each `DeprecatedAppSetting` definition.
- Where a setting replaces multiple settings, the new `accept_deprecated` keyword must be used to specify which deprecated setting to accept values for, otherwise values from deprecated settings will never be returned when the new setting is referenced.