### PR TITLE
Adds a 'warn_only_if_overridden' argument to each get method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changelog
 0.3 (XX.XX.XXXX) (IN DEVELOPMENT)
 ----------------------------------
 
-- TBA
+- Added the ``warn_only_if_overridden`` argument to all 'value fetching' methods on ``BaseAppSettingsHelper``, which can be used to request deprecated setting values without raising the usual 'this setting is deprecated' warning, but will raise a warning if the setting is overridden.
+- Improved the consistency and usefulness of error messages raised when attribute helpers or methods are called with invalid setting names.
 
 0.2 (02.08.2018)
 ----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 - Added the ``warn_only_if_overridden`` argument to all 'value fetching' methods on ``BaseAppSettingsHelper``, which can be used to request deprecated setting values without raising the usual 'this setting is deprecated' warning, but will raise a warning if the setting is overridden.
 - Improved the consistency and usefulness of error messages raised when attribute helpers or methods are called with invalid setting names.
+- Renamed ``BaseAppSettingsHelper.raise_setting_error()`` to ``_raise_setting_value_error()`` (making it a private method).
 
 0.2 (02.08.2018)
 ----------------

--- a/cogwheels/helpers/deprecation.py
+++ b/cogwheels/helpers/deprecation.py
@@ -22,6 +22,12 @@ SIMPLE_DEPRECATION_WARNING_FORMAT = (
     "{removed_in_version}."
 )
 
+DEPRECATED_SETTING_OVERRIDDEN_WARNING_FORMAT = (
+    "The {prefix}_{setting_name} setting is deprecated. The override value "
+    "from your project's Django settings will no longer have any affect "
+    "once support is removed in {removed_in_version}."
+)
+
 COMMON_OLD_SETTING_USED_WARNING_FORMAT = (
     "Please update your Django settings to use the new setting, otherwise the "
     "app will revert to it's default behaviour once support for "
@@ -78,6 +84,13 @@ class DeprecatedAppSetting:
             setting_name=self.setting_name,
             replacement_name=self.replacement_name,
             removed_in_version=self.get_removed_in_version_text(),
+        )
+
+    def warn_if_overridden(self, stacklevel=2):
+        warnings.warn(
+            self._make_warning_message(DEPRECATED_SETTING_OVERRIDDEN_WARNING_FORMAT),
+            category=self.warning_category,
+            stacklevel=stacklevel,
         )
 
     def warn_if_deprecated_setting_value_requested(self, stacklevel=2):

--- a/cogwheels/helpers/deprecation.py
+++ b/cogwheels/helpers/deprecation.py
@@ -87,6 +87,8 @@ class DeprecatedAppSetting:
         )
 
     def warn_if_overridden(self, stacklevel=2):
+        # TODO: Figure out a clean way to raise this warning so that it appears
+        # to come from the override setting definition in the user's Django settings.
         warnings.warn(
             self._make_warning_message(DEPRECATED_SETTING_OVERRIDDEN_WARNING_FORMAT),
             category=self.warning_category,

--- a/cogwheels/helpers/settings.py
+++ b/cogwheels/helpers/settings.py
@@ -55,7 +55,7 @@ class BaseAppSettingsHelper:
         invalid.
         """
         if not self.in_defaults(name):
-            self.raise_invalid_setting_name_error(name, error_class=AttributeError)
+            self._raise_invalid_setting_name_error(name, error_class=AttributeError)
         return self.get(name, warning_stacklevel=4)
 
     def _set_prefix(self, init_supplied_val):
@@ -234,7 +234,7 @@ class BaseAppSettingsHelper:
         attr_name = self.get_prefixed_setting_name(setting_name)
         return hasattr(django_settings, attr_name)
 
-    def raise_invalid_setting_name_error(self, setting_name, error_class=ValueError):
+    def _raise_invalid_setting_name_error(self, setting_name, error_class=ValueError):
         raise error_class(
             "'{}' is not a valid setting name. Valid settings names for "
             "{} are: {}." .format(
@@ -244,7 +244,7 @@ class BaseAppSettingsHelper:
             )
         )
 
-    def raise_setting_value_error(
+    def _raise_setting_value_error(
         self, setting_name, additional_text,
         user_value_error_class=None, default_value_error_class=None,
         **text_format_kwargs
@@ -313,7 +313,7 @@ class BaseAppSettingsHelper:
         relevant value from the defaults module is returned.
         """
         if not self.in_defaults(setting_name):
-            self.raise_invalid_setting_name_error(setting_name)
+            self._raise_invalid_setting_name_error(setting_name)
 
         if self.is_overridden(setting_name):
             if(
@@ -347,9 +347,9 @@ class BaseAppSettingsHelper:
         setting in their Django settings to override behaviour.
         """
         if not self.in_defaults(setting_name):
-            self.raise_invalid_setting_name_error(setting_name)
+            self._raise_invalid_setting_name_error(setting_name)
         if not self.in_defaults(deprecated_setting_name):
-            self.raise_invalid_setting_name_error(deprecated_setting_name)
+            self._raise_invalid_setting_name_error(deprecated_setting_name)
         if deprecated_setting_name not in self._deprecated_settings:
             raise ValueError(
                 "The '%s' setting is not deprecated. When using "
@@ -419,7 +419,7 @@ class BaseAppSettingsHelper:
                     current_type=type(result).__name__,
                     required_type=enforce_type.__name__,
                 )
-            self.raise_setting_value_error(
+            self._raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueTypeInvalid,
                 default_value_error_class=DefaultValueTypeInvalid,
@@ -466,7 +466,7 @@ class BaseAppSettingsHelper:
             self._models_cache[cache_key] = result
             return result
         except ValueError:
-            self.raise_setting_value_error(
+            self._raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueFormatInvalid,
                 default_value_error_class=DefaultValueFormatInvalid,
@@ -477,7 +477,7 @@ class BaseAppSettingsHelper:
                 value=raw_value,
             )
         except LookupError:
-            self.raise_setting_value_error(
+            self._raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueNotImportable,
                 default_value_error_class=DefaultValueNotImportable,
@@ -520,7 +520,7 @@ class BaseAppSettingsHelper:
             self._modules_cache[cache_key] = result
             return result
         except ImportError:
-            self.raise_setting_value_error(
+            self._raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueNotImportable,
                 default_value_error_class=DefaultValueNotImportable,
@@ -563,7 +563,7 @@ class BaseAppSettingsHelper:
         try:
             module_path, object_name = raw_value.rsplit(".", 1)
         except ValueError:
-            self.raise_setting_value_error(
+            self._raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueFormatInvalid,
                 default_value_error_class=DefaultValueFormatInvalid,
@@ -579,7 +579,7 @@ class BaseAppSettingsHelper:
             self._objects_cache[cache_key] = result
             return result
         except ImportError:
-            self.raise_setting_value_error(
+            self._raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueNotImportable,
                 default_value_error_class=DefaultValueNotImportable,
@@ -592,7 +592,7 @@ class BaseAppSettingsHelper:
                 module_path=module_path,
             )
         except AttributeError:
-            self.raise_setting_value_error(
+            self._raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueNotImportable,
                 default_value_error_class=DefaultValueNotImportable,

--- a/cogwheels/helpers/settings.py
+++ b/cogwheels/helpers/settings.py
@@ -58,6 +58,7 @@ class BaseAppSettingsHelper:
         if not self.in_defaults(name):
             raise AttributeError("{} object has no attribute '{}'".format(
                 self.__class__.__name__, name))
+            )
         return self.get(name, warning_stacklevel=4)
 
     def _set_prefix(self, init_supplied_val):

--- a/cogwheels/helpers/settings.py
+++ b/cogwheels/helpers/settings.py
@@ -215,10 +215,7 @@ class BaseAppSettingsHelper:
         return setting_name in self._defaults
 
     def get_default_value(self, setting_name):
-        try:
-            return self._defaults[setting_name]
-        except KeyError:
-            pass
+        return self._defaults[setting_name]
 
     def get_prefix(self):
         return self._prefix + '_'

--- a/cogwheels/helpers/settings.py
+++ b/cogwheels/helpers/settings.py
@@ -245,7 +245,7 @@ class BaseAppSettingsHelper:
         attr_name = self.get_prefixed_setting_name(setting_name)
         return hasattr(django_settings, attr_name)
 
-    def raise_setting_error(
+    def raise_setting_value_error(
         self, setting_name, additional_text,
         user_value_error_class=None, default_value_error_class=None,
         **text_format_kwargs
@@ -391,7 +391,7 @@ class BaseAppSettingsHelper:
                     current_type=type(result).__name__,
                     required_type=enforce_type.__name__,
                 )
-            self.raise_setting_error(
+            self.raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueTypeInvalid,
                 default_value_error_class=DefaultValueTypeInvalid,
@@ -437,7 +437,7 @@ class BaseAppSettingsHelper:
             self._models_cache[cache_key] = result
             return result
         except ValueError:
-            self.raise_setting_error(
+            self.raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueFormatInvalid,
                 default_value_error_class=DefaultValueFormatInvalid,
@@ -448,7 +448,7 @@ class BaseAppSettingsHelper:
                 value=raw_value,
             )
         except LookupError:
-            self.raise_setting_error(
+            self.raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueNotImportable,
                 default_value_error_class=DefaultValueNotImportable,
@@ -490,7 +490,7 @@ class BaseAppSettingsHelper:
             self._modules_cache[cache_key] = result
             return result
         except ImportError:
-            self.raise_setting_error(
+            self.raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueNotImportable,
                 default_value_error_class=DefaultValueNotImportable,
@@ -532,7 +532,7 @@ class BaseAppSettingsHelper:
         try:
             module_path, object_name = raw_value.rsplit(".", 1)
         except ValueError:
-            self.raise_setting_error(
+            self.raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueFormatInvalid,
                 default_value_error_class=DefaultValueFormatInvalid,
@@ -548,7 +548,7 @@ class BaseAppSettingsHelper:
             self._objects_cache[cache_key] = result
             return result
         except ImportError:
-            self.raise_setting_error(
+            self.raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueNotImportable,
                 default_value_error_class=DefaultValueNotImportable,
@@ -561,7 +561,7 @@ class BaseAppSettingsHelper:
                 module_path=module_path,
             )
         except AttributeError:
-            self.raise_setting_error(
+            self.raise_setting_value_error(
                 setting_name=setting_name,
                 user_value_error_class=OverrideValueNotImportable,
                 default_value_error_class=DefaultValueNotImportable,

--- a/cogwheels/helpers/tests/test_get.py
+++ b/cogwheels/helpers/tests/test_get.py
@@ -1,5 +1,4 @@
 import warnings
-from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 
 from cogwheels import DefaultValueTypeInvalid
@@ -10,7 +9,7 @@ from cogwheels.tests.conf import defaults
 class TestGetMethod(AppSettingTestCase):
 
     def test_raises_error_if_no_default_defined(self):
-        with self.assertRaises(ImproperlyConfigured):
+        with self.assertRaises(ValueError):
             self.appsettingshelper.get('NOT_REAL_SETTING')
 
     def test_integer_setting_returns_default_value_by_default(self):

--- a/cogwheels/helpers/tests/test_get.py
+++ b/cogwheels/helpers/tests/test_get.py
@@ -97,6 +97,19 @@ class TestDeprecatedSetting(AppSettingTestCase):
             self.appsettingshelper.get('DEPRECATED_SETTING')
             self.assertEqual(len(w), 3)
 
+    def test_warning_not_raised_if_not_overridden_and_warn_only_if_overridden_is_true(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.appsettingshelper.get('DEPRECATED_SETTING', warn_only_if_overridden=True)
+        self.assertEqual(len(w), 0)
+
+    @override_settings(COGWHEELS_TESTS_DEPRECATED_SETTING='blah')
+    def test_warning_is_raised_if_overridden_and_warn_only_if_overrridden_is_true(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.appsettingshelper.get('DEPRECATED_SETTING', warn_only_if_overridden=True)
+        self.assertEqual(len(w), 1)
+
 
 class TestRenamedSetting(AppSettingTestCase):
 

--- a/cogwheels/helpers/tests/test_get_model.py
+++ b/cogwheels/helpers/tests/test_get_model.py
@@ -123,3 +123,16 @@ class TestReplacedModelSetting(AppSettingTestCase):
             self.appsettingshelper.get_model('REPLACED_MODEL_SETTING', suppress_warnings=True)
             self.appsettingshelper.get_model('REPLACEMENT_MODEL_SETTING', suppress_warnings=True)
             self.assertEqual(len(w), 0)
+
+    def test_warning_not_raised_if_not_overridden_and_warn_only_if_overridden_is_true(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.appsettingshelper.get_model('REPLACED_MODEL_SETTING', warn_only_if_overridden=True)
+        self.assertEqual(len(w), 0)
+
+    @override_settings(COGWHEELS_TESTS_REPLACED_MODEL_SETTING='tests.ReplacementModel')
+    def test_warning_is_raised_if_overridden_and_warn_only_if_overrridden_is_true(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.appsettingshelper.get_model('REPLACED_MODEL_SETTING', warn_only_if_overridden=True)
+        self.assertEqual(len(w), 1)

--- a/cogwheels/helpers/tests/test_get_module.py
+++ b/cogwheels/helpers/tests/test_get_module.py
@@ -108,7 +108,7 @@ class TestReplacedModuleSetting(AppSettingTestCase):
                 str(w[0])
             )
 
-    @override_settings(COGWHEELS_TESTS_REPLACED_MODEL_SETTING='cogwheels.tests.modules.replacement_module')
+    @override_settings(COGWHEELS_TESTS_REPLACED_MODULE_SETTING='cogwheels.tests.modules.replacement_module')
     def test_using_suppress_warnings_has_the_desired_effect(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/cogwheels/helpers/tests/test_get_module.py
+++ b/cogwheels/helpers/tests/test_get_module.py
@@ -115,3 +115,16 @@ class TestReplacedModuleSetting(AppSettingTestCase):
             self.appsettingshelper.get_module('REPLACED_MODULE_SETTING', suppress_warnings=True)
             self.appsettingshelper.get_module('REPLACEMENT_MODULE_SETTING', suppress_warnings=True)
             self.assertEqual(len(w), 0)
+
+    def test_warning_not_raised_if_not_overridden_and_warn_only_if_overridden_is_true(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.appsettingshelper.get_module('REPLACED_MODULE_SETTING', warn_only_if_overridden=True)
+        self.assertEqual(len(w), 0)
+
+    @override_settings(COGWHEELS_TESTS_REPLACED_MODULE_SETTING='cogwheels.tests.modules.replacement_module')
+    def test_warning_is_raised_if_overridden_and_warn_only_if_overrridden_is_true(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.appsettingshelper.get_module('REPLACED_MODULE_SETTING', warn_only_if_overridden=True)
+        self.assertEqual(len(w), 1)

--- a/cogwheels/helpers/tests/test_get_object.py
+++ b/cogwheels/helpers/tests/test_get_object.py
@@ -134,3 +134,16 @@ class TestReplacedObjectSetting(AppSettingTestCase):
             self.appsettingshelper.get_object('REPLACED_OBJECT_SETTING', suppress_warnings=True)
             self.appsettingshelper.get_object('REPLACEMENT_OBJECT_SETTING', suppress_warnings=True)
             self.assertEqual(len(w), 0)
+
+    def test_warning_not_raised_if_not_overridden_and_warn_only_if_overridden_is_true(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.appsettingshelper.get_object('REPLACED_OBJECT_SETTING', warn_only_if_overridden=True)
+        self.assertEqual(len(w), 0)
+
+    @override_settings(COGWHEELS_TESTS_REPLACED_OBJECT_SETTING='cogwheels.tests.classes.ReplacementClass')
+    def test_warning_is_raised_if_overridden_and_warn_only_if_overrridden_is_true(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.appsettingshelper.get_object('REPLACED_OBJECT_SETTING', warn_only_if_overridden=True)
+        self.assertEqual(len(w), 1)

--- a/cogwheels/helpers/tests/test_get_object.py
+++ b/cogwheels/helpers/tests/test_get_object.py
@@ -127,7 +127,7 @@ class TestReplacedObjectSetting(AppSettingTestCase):
                 str(w[0])
             )
 
-    @override_settings(COGWHEELS_TESTS_REPLACED_MODEL_SETTING='cogwheels.tests.classes.ReplacementClass')
+    @override_settings(COGWHEELS_TESTS_REPLACED_OBJECT_SETTING='cogwheels.tests.classes.ReplacementClass')
     def test_using_suppress_warnings_has_the_desired_effect(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/cogwheels/helpers/tests/test_helper_attribute_shortcuts.py
+++ b/cogwheels/helpers/tests/test_helper_attribute_shortcuts.py
@@ -17,8 +17,7 @@ class TestModelsShortcut(AppSettingTestCase):
     """
     @patch.object(BaseAppSettingsHelper, 'get_model')
     def test_raises_attributeerror_if_no_default_defined(self, mocked_method):
-        expected_message = (
-            "TestAppSettingsHelper object has no attribute 'I_DONT_THINK_SO'")
+        expected_message = "'I_DONT_THINK_SO' is not a valid setting name"
         with self.assertRaisesRegex(AttributeError, expected_message):
             self.appsettingshelper.models.I_DONT_THINK_SO
         mocked_method.assert_not_called()
@@ -54,9 +53,7 @@ class TestModulesShortcut(AppSettingTestCase):
     """
     @patch.object(BaseAppSettingsHelper, 'get_module')
     def test_raises_attributeerror_if_no_default_defined(self, mocked_method):
-        expected_message = (
-            "TestAppSettingsHelper object has no attribute "
-            "'I_DONT_THINK_SO'")
+        expected_message = "'I_DONT_THINK_SO' is not a valid setting name"
         with self.assertRaisesRegex(AttributeError, expected_message):
             self.appsettingshelper.modules.I_DONT_THINK_SO
         mocked_method.assert_not_called()
@@ -91,9 +88,7 @@ class TestObjectsShortcut(AppSettingTestCase):
     """
     @patch.object(BaseAppSettingsHelper, 'get_object')
     def test_raises_attributeerror_if_no_default_defined(self, mocked_method):
-        expected_message = (
-            "TestAppSettingsHelper object has no attribute "
-            "'I_DONT_THINK_SO'")
+        expected_message = "'I_DONT_THINK_SO' is not a valid setting name"
         with self.assertRaisesRegex(AttributeError, expected_message):
             self.appsettingshelper.objects.I_DONT_THINK_SO
         mocked_method.assert_not_called()

--- a/cogwheels/helpers/utils.py
+++ b/cogwheels/helpers/utils.py
@@ -32,9 +32,7 @@ class AttrReferToMethodHelper:
 
     def __getattr__(self, name):
         if not self.settings_helper.in_defaults(name):
-            raise AttributeError(
-                "'{}' is not a valid app setting".format(name)
-            )
+            self.settings_helper.raise_invalid_setting_name_error(name, error_class=AttributeError)
         return self.get_value_via_helper_method(name)
 
     def get_value_via_helper_method(self, setting_name):

--- a/cogwheels/helpers/utils.py
+++ b/cogwheels/helpers/utils.py
@@ -32,7 +32,7 @@ class AttrReferToMethodHelper:
 
     def __getattr__(self, name):
         if not self.settings_helper.in_defaults(name):
-            self.settings_helper.raise_invalid_setting_name_error(name, error_class=AttributeError)
+            self.settings_helper._raise_invalid_setting_name_error(name, error_class=AttributeError)
         return self.get_value_via_helper_method(name)
 
     def get_value_via_helper_method(self, setting_name):

--- a/cogwheels/helpers/utils.py
+++ b/cogwheels/helpers/utils.py
@@ -31,10 +31,11 @@ class AttrReferToMethodHelper:
         self.getter_method_name = getter_method_name
 
     def __getattr__(self, name):
-        if self.settings_helper.in_defaults(name):
-            return self.get_value_via_helper_method(name)
-        raise AttributeError("{} object has no attribute '{}'".format(
-            self.settings_helper.__class__.__name__, name))
+        if not self.settings_helper.in_defaults(name):
+            raise AttributeError(
+                "'{}' is not a valid app setting".format(name)
+            )
+        return self.get_value_via_helper_method(name)
 
     def get_value_via_helper_method(self, setting_name):
         method = getattr(self.settings_helper, self.getter_method_name)


### PR DESCRIPTION
It can be used to request access to a deprecated setting value without immediately triggering a 'this setting is deprecated' warning. However, a deprecation warning will be raised if the setting value is overridden in a user's Django settings, which hopefully users will see.

In future, it would be good to have this warning indicate the setting definition in the user's Django settings as the source of the warning (making it more likely to be seen by the user), but not sure of the best way to tackle this just yet.