### PR TITLE
Allow developers to specify when a deprecated setting will be removed

### DIFF
--- a/cogwheels/helpers/tests/test_get.py
+++ b/cogwheels/helpers/tests/test_get.py
@@ -125,7 +125,7 @@ class TestRenamedSetting(AppSettingTestCase):
                 "The RENAMED_SETTING_OLD app setting has been renamed to RENAMED_SETTING_NEW. "
                 "Please update your code to reference the new setting, as continuing to reference "
                 "RENAMED_SETTING_OLD will cause an exception to be raised once support is removed "
-                "in the next version.",
+                "in 1.7.",
                 str(w[0])
             )
 
@@ -148,7 +148,7 @@ class TestRenamedSetting(AppSettingTestCase):
             "The COGWHEELS_TESTS_RENAMED_SETTING_OLD setting has been renamed to "
             "COGWHEELS_TESTS_RENAMED_SETTING_NEW. Please update your Django settings to use the "
             "new setting, otherwise the app will revert to it's default behaviour once support for "
-            "COGWHEELS_TESTS_RENAMED_SETTING_OLD is removed in the next version.",
+            "COGWHEELS_TESTS_RENAMED_SETTING_OLD is removed in 1.7.",
             str(cm.warning)
         )
 
@@ -167,7 +167,7 @@ class TestReplacedSetting(AppSettingTestCase):
                 "The REPLACED_SETTING app setting is deprecated in favour of using "
                 "REPLACEMENT_SETTING. Please update your code to reference the new setting, as "
                 "continuing to reference REPLACED_SETTING will cause an exception to be raised "
-                "once support is removed in two versions time.",
+                "once support is removed in 1.8.",
                 str(w[0])
             )
             # The additional guidance should be present also
@@ -194,7 +194,7 @@ class TestReplacedSetting(AppSettingTestCase):
             "The COGWHEELS_TESTS_REPLACED_SETTING setting is deprecated in favour of using "
             "COGWHEELS_TESTS_REPLACEMENT_SETTING. Please update your Django settings to use the "
             "new setting, otherwise the app will revert to it's default behaviour once support for "
-            "COGWHEELS_TESTS_REPLACED_SETTING is removed in two versions time.",
+            "COGWHEELS_TESTS_REPLACED_SETTING is removed in 1.8.",
             str(cm.warning)
         )
         # The additional guidance should be present also

--- a/cogwheels/tests/conf/settings.py
+++ b/cogwheels/tests/conf/settings.py
@@ -17,12 +17,14 @@ class TestAppSettingsHelper(BaseAppSettingsHelper):
             'RENAMED_SETTING_OLD',
             renamed_to='RENAMED_SETTING_NEW',
             warning_category=DeprecationWarning,
+            removing_in='1.7',
         ),
         DeprecatedAppSetting(
             'REPLACED_SETTING',
             replaced_by='REPLACEMENT_SETTING',
+            additional_guidance=COMPLEX_REPLACEMENT_GUIDANCE,
             warning_category=PendingDeprecationWarning,
-            additional_guidance=COMPLEX_REPLACEMENT_GUIDANCE
+            removing_in='1.8',
         ),
         DeprecatedAppSetting(
             'REPLACED_MODEL_SETTING',


### PR DESCRIPTION
Added support for a `removing_in` argument when defining instances of `DeprecatedAppSetting`. If supplied, it will be used in warning messages instead of 'the next release' or 'two releases time' (derived from the `warning_category`)