### PR TITLE
Adds a custom UnknownSettingNameError exception class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 ----------------------------------
 
 - Added the ``warn_only_if_overridden`` argument to all 'value fetching' methods on ``BaseAppSettingsHelper``, which can be used to request deprecated setting values without raising the usual 'this setting is deprecated' warning, but will raise a warning if the setting is overridden.
-- Improved the consistency and usefulness of error messages raised when attribute helpers or methods are called with invalid setting names.
+- Improved the consistency of error messages raised when attribute helpers or methods are called with invalid setting names, by introducing a new ``UnknownSettingNameError`` exception class and more helpful messaging.
 - Renamed ``BaseAppSettingsHelper.raise_setting_error()`` to ``_raise_setting_value_error()`` (making it a private method).
 
 0.2 (02.08.2018)

--- a/cogwheels/__init__.py
+++ b/cogwheels/__init__.py
@@ -8,5 +8,6 @@ from .exceptions import ( # noqa
     DefaultValueFormatInvalid, DefaultValueNotImportable,
     OverrideValueError, OverrideValueTypeInvalid,
     OverrideValueFormatInvalid, OverrideValueNotImportable,
+    UnknownSettingNameError
 )
 from .helpers import BaseAppSettingsHelper, DeprecatedAppSetting # noqa

--- a/cogwheels/exceptions/settings.py
+++ b/cogwheels/exceptions/settings.py
@@ -1,7 +1,5 @@
 from django.core.exceptions import ImproperlyConfigured
 
-"""Errors relating to a specific setting value"""
-
 
 # -----------------------------------------------------------------------------
 # Common setting value errors
@@ -79,4 +77,17 @@ class OverrideValueFormatInvalid(SettingValueFormatInvalid, OverrideValueError):
 
 class OverrideValueNotImportable(SettingValueNotImportable, OverrideValueError):
     """As SettingValueNotImportable, but specifically for a 'user-provided' value."""
+    pass
+
+
+# -----------------------------------------------------------------------------
+# Misc exceptions
+# -----------------------------------------------------------------------------
+
+class UnknownSettingNameError(AttributeError, ValueError):
+    """A setting name used for a request does not match any settings defined
+    in a helper's associated defaults module. The setting name may have been
+    provided as a string, in which case ValueError is appropriate. But, it may
+    have also been referenced as a attribute, in which case AttributError is
+    also appropriate."""
     pass

--- a/cogwheels/helpers/settings.py
+++ b/cogwheels/helpers/settings.py
@@ -7,6 +7,7 @@ from cogwheels import (
     OverrideValueFormatInvalid, OverrideValueNotImportable,
     DefaultValueError, DefaultValueTypeInvalid,
     DefaultValueFormatInvalid, DefaultValueNotImportable,
+    UnknownSettingNameError
 )
 from cogwheels.exceptions.deprecations import (
     IncorrectDeprecationsValueType, InvalidDeprecationDefinition,
@@ -84,8 +85,11 @@ class BaseAppSettingsHelper:
         Raises an ``AttributeError`` if the requested attribute is not a valid
         setting name.
         """
+        if not name.isupper():
+            raise AttributeError("{} object has no attribute '{}'".format(
+                self.__class__.__name__, name))
         if not self.in_defaults(name):
-            self._raise_invalid_setting_name_error(name, error_class=AttributeError)
+            self._raise_invalid_setting_name_error(name)
         return self.get(name, warning_stacklevel=4)
 
     def _set_prefix(self, init_supplied_val):
@@ -285,8 +289,8 @@ class BaseAppSettingsHelper:
         attr_name = self.get_prefixed_setting_name(setting_name)
         return hasattr(django_settings, attr_name)
 
-    def _raise_invalid_setting_name_error(self, setting_name, error_class=ValueError):
-        raise error_class(
+    def _raise_invalid_setting_name_error(self, setting_name):
+        raise UnknownSettingNameError(
             "'{}' is not a valid setting name. Valid settings names for "
             "{} are: {}." .format(
                 setting_name,
@@ -443,8 +447,7 @@ class BaseAppSettingsHelper:
             ``warnings.warn()`` method, to help give a more accurate indication
             of the code that caused the warning to be raised.
         :type warning_stacklevel: int
-        :raises:
-            ValueError, SettingValueTypeInvalid
+        :raises: UnknownSettingNameError, SettingValueTypeInvalid
 
         Instead of calling this method directly, developers are generally
         encouraged to use the direct attribute shortcut, which is a
@@ -541,8 +544,8 @@ class BaseAppSettingsHelper:
             of the code that caused the warning to be raised.
         :type warning_stacklevel: int
         :raises:
-            ValueError, SettingValueTypeInvalid, SettingValueFormatInvalid,
-            SettingValueNotImportable
+            UnknownSettingNameError, SettingValueTypeInvalid,
+            SettingValueFormatInvalid, SettingValueNotImportable
 
         Instead of calling this method directly, developers are generally
         encouraged to use the ``models`` attribute shortcut, which is a
@@ -638,7 +641,8 @@ class BaseAppSettingsHelper:
             of the code that caused the warning to be raised.
         :type warning_stacklevel: int
         :raises:
-            ValueError, SettingValueTypeInvalid, SettingValueNotImportable
+            UnknownSettingNameError, SettingValueTypeInvalid,
+            SettingValueNotImportable
 
         Instead of calling this method directly, developers are generally
         encouraged to use the ``modules`` attribute shortcut, which is a
@@ -724,7 +728,7 @@ class BaseAppSettingsHelper:
             of the code that caused the warning to be raised.
         :type warning_stacklevel: int
         :raises:
-            ValueError, SettingValueTypeInvalid,
+            UnknownSettingNameError, SettingValueTypeInvalid,
             SettingValueFormatInvalid, SettingValueNotImportable
 
         Instead of calling this method directly, developers are generally

--- a/cogwheels/helpers/tests/test_helper_attribute_shortcuts.py
+++ b/cogwheels/helpers/tests/test_helper_attribute_shortcuts.py
@@ -1,7 +1,31 @@
 from unittest.mock import patch
 
+from cogwheels import UnknownSettingNameError
 from cogwheels.helpers import BaseAppSettingsHelper
 from cogwheels.tests.base import AppSettingTestCase
+
+
+class TestDirectAttributeShortcut(AppSettingTestCase):
+
+    @patch.object(BaseAppSettingsHelper, 'get')
+    def test_raises_unknownsettingnameerror_if_no_default_defined(self, mocked_method):
+        expected_message = "'UNKNOWN_SETTING' is not a valid setting name"
+        with self.assertRaisesRegex(UnknownSettingNameError, expected_message):
+            self.appsettingshelper.UNKNOWN_SETTING
+        mocked_method.assert_not_called()
+
+    @patch.object(BaseAppSettingsHelper, 'get')
+    def test_raises_simple_attributeerror_if_non_uppercase_attribute_not_found(self, mocked_method):
+        for attribute_name in (
+            'lower_case_attr',
+            'MIXED_case_attr'
+            'CamelCaseAttr'
+        ):
+            try:
+                getattr(self.appsettingshelper, attribute_name)
+            except AttributeError as e:
+                self.assertNotIsInstance(e, UnknownSettingNameError)
+        mocked_method.assert_not_called()
 
 
 class TestModelsShortcut(AppSettingTestCase):
@@ -16,10 +40,23 @@ class TestModelsShortcut(AppSettingTestCase):
     know there is no such setting).
     """
     @patch.object(BaseAppSettingsHelper, 'get_model')
-    def test_raises_attributeerror_if_no_default_defined(self, mocked_method):
-        expected_message = "'I_DONT_THINK_SO' is not a valid setting name"
-        with self.assertRaisesRegex(AttributeError, expected_message):
-            self.appsettingshelper.models.I_DONT_THINK_SO
+    def test_raises_unknownsettingnameerror_if_no_default_defined(self, mocked_method):
+        expected_message = "'UNKNOWN_SETTING' is not a valid setting name"
+        with self.assertRaisesRegex(UnknownSettingNameError, expected_message):
+            self.appsettingshelper.models.UNKNOWN_SETTING
+        mocked_method.assert_not_called()
+
+    @patch.object(BaseAppSettingsHelper, 'get_model')
+    def test_raises_simple_attributeerror_if_non_uppercase_attribute_not_found(self, mocked_method):
+        for attribute_name in (
+            'lower_case_attr',
+            'MIXED_case_attr'
+            'CamelCaseAttr'
+        ):
+            try:
+                getattr(self.appsettingshelper.models, attribute_name)
+            except AttributeError as e:
+                self.assertNotIsInstance(e, UnknownSettingNameError)
         mocked_method.assert_not_called()
 
     @patch.object(BaseAppSettingsHelper, 'get_model')
@@ -52,10 +89,23 @@ class TestModulesShortcut(AppSettingTestCase):
     know there is no such setting).
     """
     @patch.object(BaseAppSettingsHelper, 'get_module')
-    def test_raises_attributeerror_if_no_default_defined(self, mocked_method):
-        expected_message = "'I_DONT_THINK_SO' is not a valid setting name"
-        with self.assertRaisesRegex(AttributeError, expected_message):
-            self.appsettingshelper.modules.I_DONT_THINK_SO
+    def test_raises_unknownsettingnameerror_if_no_default_defined(self, mocked_method):
+        expected_message = "'UNKNOWN_SETTING' is not a valid setting name"
+        with self.assertRaisesRegex(UnknownSettingNameError, expected_message):
+            self.appsettingshelper.modules.UNKNOWN_SETTING
+        mocked_method.assert_not_called()
+
+    @patch.object(BaseAppSettingsHelper, 'get_module')
+    def test_raises_simple_attributeerror_if_non_uppercase_attribute_not_found(self, mocked_method):
+        for attribute_name in (
+            'lower_case_attr',
+            'MIXED_case_attr'
+            'CamelCaseAttr'
+        ):
+            try:
+                getattr(self.appsettingshelper.modules, attribute_name)
+            except AttributeError as e:
+                self.assertNotIsInstance(e, UnknownSettingNameError)
         mocked_method.assert_not_called()
 
     @patch.object(BaseAppSettingsHelper, 'get_module')
@@ -87,10 +137,23 @@ class TestObjectsShortcut(AppSettingTestCase):
     default value defined
     """
     @patch.object(BaseAppSettingsHelper, 'get_object')
-    def test_raises_attributeerror_if_no_default_defined(self, mocked_method):
-        expected_message = "'I_DONT_THINK_SO' is not a valid setting name"
-        with self.assertRaisesRegex(AttributeError, expected_message):
-            self.appsettingshelper.objects.I_DONT_THINK_SO
+    def test_raises_unknownsettingnameerror_if_setting_not_in_defaults(self, mocked_method):
+        expected_message = "'UNKNOWN_SETTING' is not a valid setting name"
+        with self.assertRaisesRegex(UnknownSettingNameError, expected_message):
+            self.appsettingshelper.objects.UNKNOWN_SETTING
+        mocked_method.assert_not_called()
+
+    @patch.object(BaseAppSettingsHelper, 'get_object')
+    def test_raises_simple_attributeerror_if_non_uppercase_attribute_not_found(self, mocked_method):
+        for attribute_name in (
+            'lower_case_attr',
+            'MIXED_case_attr'
+            'CamelCaseAttr'
+        ):
+            try:
+                getattr(self.appsettingshelper.objects, attribute_name)
+            except AttributeError as e:
+                self.assertNotIsInstance(e, UnknownSettingNameError)
         mocked_method.assert_not_called()
 
     @patch.object(BaseAppSettingsHelper, 'get_object')

--- a/cogwheels/helpers/utils.py
+++ b/cogwheels/helpers/utils.py
@@ -25,8 +25,11 @@ class AttrReferToMethodHelper:
         self.getter_method_name = getter_method_name
 
     def __getattr__(self, name):
+        if not name.isupper():
+            raise AttributeError("{} object has no attribute '{}'".format(
+                self.__class__.__name__, name))
         if not self.settings_helper.in_defaults(name):
-            self.settings_helper._raise_invalid_setting_name_error(name, error_class=AttributeError)
+            self.settings_helper._raise_invalid_setting_name_error(name)
         return self.get_value_via_helper_method(name)
 
     def get_value_via_helper_method(self, setting_name):


### PR DESCRIPTION
Resolves issue #11.

Replaces PR #12.

- Added a custom `UnknownSettingNameError` exception that subclasses both ValueError and AttributeError, making it appropriate for different contexts
- Updates `__getattr__()` overrides to raise a simple/standard AttributeError when a lower or mixed case attribute name is requested
- Updates `_raise_invalid_setting_name_error()` to always use the new `UnknownSettingNameError` class for raising